### PR TITLE
Increase AWS IOPs and GCP GPU count

### DIFF
--- a/terraform-aws/main.tf
+++ b/terraform-aws/main.tf
@@ -18,7 +18,7 @@ resource "aws_instance" "web_app" {
     device_name = "my_data"
     volume_type = "io1"                     # <<<<< Try changing this to gp2 to compare costs
     volume_size = 1000
-    iops        = 700
+    iops        = 800
   }
 }
 

--- a/terraform-gcp/main.tf
+++ b/terraform-gcp/main.tf
@@ -20,7 +20,7 @@ resource "google_compute_instance" "instance1" {
 
   guest_accelerator {
     type = "nvidia-tesla-t4" # <<<<< Try changing this to nvidia-tesla-p4 to compare the costs
-    count = 3
+    count = 4
   }
 
   network_interface {


### PR DESCRIPTION
On the first comment, expand the Show Output sections and scroll down to see the Infracost output.