### PR TITLE
Increase AWS IOPs and GCP GPU count

### DIFF
--- a/terraform-aws/main.tf
+++ b/terraform-aws/main.tf
@@ -17,8 +17,8 @@ resource "aws_instance" "web_app" {
   ebs_block_device {
     device_name = "my_data"
     volume_type = "io1"                     # <<<<< Try changing this to gp2 to compare costs
-    volume_size = 1000
-    iops        = 800
+    volume_size = 3000
+    iops        = 1200
   }
 }
 

--- a/terraform-gcp/main.tf
+++ b/terraform-gcp/main.tf
@@ -20,7 +20,7 @@ resource "google_compute_instance" "instance1" {
 
   guest_accelerator {
     type = "nvidia-tesla-t4" # <<<<< Try changing this to nvidia-tesla-p4 to compare the costs
-    count = 3
+    count = 4
   }
 
   network_interface {

--- a/terraform-gcp/main.tf
+++ b/terraform-gcp/main.tf
@@ -20,7 +20,7 @@ resource "google_compute_instance" "instance1" {
 
   guest_accelerator {
     type = "nvidia-tesla-t4" # <<<<< Try changing this to nvidia-tesla-p4 to compare the costs
-    count = 4
+    count = 3
   }
 
   network_interface {


### PR DESCRIPTION
# User description
Increase storage size and IOPs

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
<p>Increase the storage size and IOPs for AWS instances by modifying the <code>volume_size</code> and <code>iops</code> parameters in the <code>aws_instance</code> resource configuration.</p>
    <table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/infracost/atlantis-demo/6?tool=ast&topic=AWS+Storage+Update>AWS Storage Update</a>
        </td><td>Modify AWS instance storage parameters to enhance performance.<details><summary>Modified files (1)</summary><ul><li>terraform-aws/main.tf</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>Email</th><th>Commit</th><th>Date</th></tr><tr><td>alikhajeh1@googlemail.com</td><td>Update-IOPS</td><td>April 15, 2021</td></tr></table></details></td></tr></table>This pull request is reviewed by Baz. Join @alikhajeh1 and the rest of your team on <a href=https://baz.co/login>(Baz)</a>.
    